### PR TITLE
Updates for use with Symfony 3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
         class: Socialbit\SonataMediaTwigExtensionBundle\Twig\MediaPathExtension
         public: false
         arguments:
-            - @service_container
-            - @sonata.media.manager.media
+            - '@service_container'
+            - '@sonata.media.manager.media'
         tags:
             - { name: twig.extension }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   ],
   "require": {
-    "doctrine/orm": "~2.2,>=2.2.3",
-    "symfony/symfony": "~2.6.1",
-    "sonata-project/media-bundle": "~2.3"
+    "doctrine/orm": ">=2.2,>=2.2.3",
+    "symfony/symfony": ">=2.6.1",
+    "sonata-project/media-bundle": ">=2.3"
   },
   "suggest": {
     "doctrine/doctrine-migrations-bundle": "~2.1@dev"


### PR DESCRIPTION
This set of changes makes the bundle get along with Symfony 3 a bit better. 

The first and second edits avoid errors that pop up (when using the bundle with Symfony 3) complaining about Symfony version and invalid yaml, respectively. 

Other problems may still exist when using this bundle with Symfony 3 -- I haven't fully tested the setup  yet.